### PR TITLE
autograd is needed if you want to run PSF extraction

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - scipy>=0.15
   - healpy
   - ipykernel
+  - autograd
   # conda-forge pytables 3.5.0 segfaults on perfectly
   # normal datasets
   - pytables<3.5.0


### PR DESCRIPTION
`autograd` is needed to do PSF extraction. Probably didn't need to be it's own branch and PR, but oh well.