### PR TITLE
Disable auto-suggested changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,4 @@ jobs:
         uses: rickstaa/action-black@v1
         id: action_black
         with:
-          black_args: "."
-      - name: Annotate diff changes using reviewdog
-        if: steps.action_black.outputs.is_formatted == 'true'
-        uses: reviewdog/action-suggester@v1
-        with:
-          tool_name: blackfmt
+          black_args: ". --check --diff"


### PR DESCRIPTION
These encouraged rapid-fire commits that led to excessive CI runs; see #34, and were also kind of annoying. Just making the check fail is enough.