### PR TITLE
Update lockfile for micromamba 2.0

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -6684,39 +6684,39 @@ package:
   manager: pip
   platform: linux-64
   dependencies: {}
-  url: https://github.com/IceCube-SPNO/dashi/archive/refs/tags/v2.0.0.tar.gz
+  url: https://github.com/IceCube-SPNO/dashi/releases/download/v2.0.0/pydashi-2.0.0-py3-none-any.whl
   hash:
-    sha256: dde4d041e16d64e04e704f3f594c9158e3b0d6a5099fecf634a8b502e292d0bb
+    sha256: 17b8136aae7858efbf756c3c6bb97031ec1287e47e32a0119a28917b17cd854e
   category: main
   source:
     type: url
-    url: https://github.com/IceCube-SPNO/dashi/archive/refs/tags/v2.0.0.tar.gz#sha256=dde4d041e16d64e04e704f3f594c9158e3b0d6a5099fecf634a8b502e292d0bb
+    url: https://github.com/IceCube-SPNO/dashi/releases/download/v2.0.0/pydashi-2.0.0-py3-none-any.whl
   optional: false
 - name: pydashi
   version: 2.0.0
   manager: pip
   platform: osx-64
   dependencies: {}
-  url: https://github.com/IceCube-SPNO/dashi/archive/refs/tags/v2.0.0.tar.gz
+  url: https://github.com/IceCube-SPNO/dashi/releases/download/v2.0.0/pydashi-2.0.0-py3-none-any.whl
   hash:
-    sha256: dde4d041e16d64e04e704f3f594c9158e3b0d6a5099fecf634a8b502e292d0bb
+    sha256: 17b8136aae7858efbf756c3c6bb97031ec1287e47e32a0119a28917b17cd854e
   category: main
   source:
     type: url
-    url: https://github.com/IceCube-SPNO/dashi/archive/refs/tags/v2.0.0.tar.gz#sha256=dde4d041e16d64e04e704f3f594c9158e3b0d6a5099fecf634a8b502e292d0bb
+    url: https://github.com/IceCube-SPNO/dashi/releases/download/v2.0.0/pydashi-2.0.0-py3-none-any.whl
   optional: false
 - name: pydashi
   version: 2.0.0
   manager: pip
   platform: osx-arm64
   dependencies: {}
-  url: https://github.com/IceCube-SPNO/dashi/archive/refs/tags/v2.0.0.tar.gz
+  url: https://github.com/IceCube-SPNO/dashi/releases/download/v2.0.0/pydashi-2.0.0-py3-none-any.whl
   hash:
-    sha256: dde4d041e16d64e04e704f3f594c9158e3b0d6a5099fecf634a8b502e292d0bb
+    sha256: 17b8136aae7858efbf756c3c6bb97031ec1287e47e32a0119a28917b17cd854e
   category: main
   source:
     type: url
-    url: https://github.com/IceCube-SPNO/dashi/archive/refs/tags/v2.0.0.tar.gz#sha256=dde4d041e16d64e04e704f3f594c9158e3b0d6a5099fecf634a8b502e292d0bb
+    url: https://github.com/IceCube-SPNO/dashi/releases/download/v2.0.0/pydashi-2.0.0-py3-none-any.whl
   optional: false
 - name: pytest-pinned
   version: 0.4.2

--- a/environment.yml
+++ b/environment.yml
@@ -23,5 +23,5 @@ dependencies:
   - pip
   - pip:
     - easy-cache >=2
-    - pydashi @ https://github.com/IceCube-SPNO/dashi/archive/refs/tags/v2.0.0.tar.gz#sha256=dde4d041e16d64e04e704f3f594c9158e3b0d6a5099fecf634a8b502e292d0bb
+    - pydashi @ https://github.com/IceCube-SPNO/dashi/releases/download/v2.0.0/pydashi-2.0.0-py3-none-any.whl
     - -e .

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
-from os import environ, mkdir, path, unlink
-from subprocess import PIPE, check_call
-
-from setuptools import find_packages
-
-cwd = path.join(path.dirname(__file__), "toise", "data")
-if not path.isdir(cwd):
-    mkdir(cwd)
-
-# if not 'ICECUBE_PASSWORD' in environ:
-#     raise EnvironmentError('You need to set the environment variable ICECUBE_PASSWORD to the icecube user password.')
-# check_call(['curl', '--fail', '-u', 'icecube:'+environ['ICECUBE_PASSWORD'], '-O', 'https://convey.icecube.wisc.edu/data/user/jvansanten/projects/2015/gen2_benchmark/data/archive.tar.gz'], cwd=cwd)
-# check_call(['tar', 'xzf', 'archive.tar.gz'], cwd=cwd)
-# unlink(path.join(path.dirname(__file__), 'toise', 'data', 'archive.tar.gz'))
-
-check_call(
-    [
-        "curl",
-        "--fail",
-        "-o",
-        "minimal-archive.tar.gz",
-        "https://www.zeuthen.desy.de/~jvsanten/toise/minimal-archive.tar.gz",
-        # "https://sandbox.zenodo.org/record/981577/files/minimal-archive.tar.gz?download=1",
-    ],
-    cwd=cwd,
-)
-check_call(["tar", "xzf", "minimal-archive.tar.gz"], cwd=cwd)
-unlink(path.join(path.dirname(__file__), "toise", "data", "minimal-archive.tar.gz"))
+from setuptools import find_packages, setup
 
 setup(
     name="toise",

--- a/toise/figures/diffuse/single_power_law.py
+++ b/toise/figures/diffuse/single_power_law.py
@@ -25,7 +25,13 @@ def make_components(aeffs, emin=1e2, emax=1e11):
     aeff, muon_aeff = copy(aeffs)
     ebins = aeff.bin_edges[0]
     mask = (ebins[1:] <= emax) & (ebins[:-1] >= emin)
-    aeff.values *= mask[(None, slice(None),) + (None,) * (aeff.values.ndim - 2)]
+    aeff.values *= mask[
+        (
+            None,
+            slice(None),
+        )
+        + (None,) * (aeff.values.ndim - 2)
+    ]
 
     atmo = diffuse.AtmosphericNu.conventional(aeff, 1, veto_threshold=None)
     atmo.prior = lambda v, **kwargs: -((v - 1) ** 2) / (2 * 0.1**2)


### PR DESCRIPTION
micromamba 2 wants:
- package names to be of the form {name}-{version}.{ext}, i.e. install from branch is no longer supported.
- package hash to be separate from URL

Fixes #59.